### PR TITLE
Reverse dns callback fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,7 +246,7 @@ class Evilscan extends EventEmitter {
         dns.reverse(ip, (err,domains) => {
             if (err) {
                 if (err.code == 'ENOTFOUND') {
-                    return cb(null);
+                    return callback(null);
                 }
 
                 // unknow error


### PR DESCRIPTION
Fix for a ReferenceError that was being thrown when using the reverse DNS module. The "cb" variable was renamed to "callback".

```
ubuntu@testing:~$ time evilscan 192.168.0.0/24 --port=80,443 --isopen --progress --reverse
Starting (0/506 0%)/usr/local/lib/node_modules/evilscan/index.js:249
                    return cb(null);
                    ^

ReferenceError: cb is not defined
    at QueryReqWrap.dns.reverse [as callback] (/usr/local/lib/node_modules/evilscan/index.js:249:21)

    at QueryReqWrap.onresolve [as oncomplete] (dns.js:197:10)
```